### PR TITLE
Enhance logging and handle timeouts in polling job

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "anime-service"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1321,11 +1321,10 @@ dependencies = [
 
 [[package]]
 name = "nyaa"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "chrono",
- "owning_ref",
  "reqwest",
  "rss",
  "thiserror",
@@ -1354,15 +1353,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "owning_ref"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
-dependencies = [
- "stable_deref_trait",
-]
 
 [[package]]
 name = "parking_lot"
@@ -2205,12 +2195,6 @@ dependencies = [
  "urlencoding",
  "uuid",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stringprep"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anime-service"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [workspace]

--- a/nyaa/Cargo.toml
+++ b/nyaa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyaa"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 ahash = "0.8.6"
 chrono = "0.4"
-owning_ref = "0.4.1"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "brotli"] }
 rss = "2"
 thiserror = "1"

--- a/nyaa/src/parsers/subs_please.rs
+++ b/nyaa/src/parsers/subs_please.rs
@@ -86,7 +86,7 @@ pub(crate) fn parse_filename(value: &str) -> PResult<ParsedDownload, InputError<
                     resolution,
                 }),
                 Some(index) => {
-                    let mut slice = &full_title[index + 2..];
+                    let mut slice = full_title[index..].trim_start_matches(['-', ' ', '#']);
                     match parse_episode_identifier(&mut slice)? {
                         None => Ok(ParsedDownload {
                             source,

--- a/src/datasource/repository/download_resolutions.rs
+++ b/src/datasource/repository/download_resolutions.rs
@@ -76,8 +76,7 @@ where
     while let Some(row) = stream.next().await {
         let download_entity = row?;
         let id = download_entity.download_id;
-        let download = download_entity.try_into()?;
-        episodes.entry(id).or_default().push(download)
+        episodes.entry(id).or_default().push(download_entity.into())
     }
     Ok(episodes)
 }


### PR DESCRIPTION
Updated some functions in the nyaa library and poller.rs to improve logging and handle timeouts more effectively. A timeout was implemented in the get_groups() function while verbose tracing was introduced in several functions for better debugging purposes.