### PR TITLE
Refactor subtitle parser for improved accuracy

### DIFF
--- a/nyaa/src/parsers/subs_please.rs
+++ b/nyaa/src/parsers/subs_please.rs
@@ -1,12 +1,13 @@
 use std::ops::RangeInclusive;
 use std::str::FromStr;
 
-use crate::parsers::{ParsedDownload, ParsedDownloadVariant, ParsedEpisode};
-use winnow::ascii::{alphanumeric1, digit1, space1};
-use winnow::combinator::{delimited, opt, permutation, preceded, rest, separated_pair};
-use winnow::error::InputError;
-use winnow::token::take_till;
+use winnow::ascii::{alphanumeric1, digit1};
+use winnow::combinator::{alt, delimited, opt, permutation, preceded, rest, separated_pair};
+use winnow::error::{ErrMode, ErrorKind, InputError, ParserError};
+use winnow::token::{take_till, take_until0};
 use winnow::{PResult, Parser};
+
+use crate::parsers::{ParsedDownload, ParsedDownloadVariant, ParsedEpisode};
 
 fn parse_digits<'s, N: FromStr>(input: &mut &'s str) -> PResult<N, InputError<&'s str>> {
     digit1.parse_to().parse_next(input)
@@ -14,6 +15,18 @@ fn parse_digits<'s, N: FromStr>(input: &mut &'s str) -> PResult<N, InputError<&'
 
 fn resolution<'s>(input: &mut &'s str) -> PResult<u16, InputError<&'s str>> {
     delimited('(', parse_digits, "p)").parse_next(input)
+}
+
+fn parse_resolution<'s>(input: &mut &'s str) -> PResult<u16, InputError<&'s str>> {
+    let full_title = alt((
+        take_until0("(1080p)"),
+        take_until0("(720p)"),
+        take_until0("(480p)"),
+    ))
+    .parse_next(input)?;
+    let resolution = resolution.parse_next(input)?;
+    *input = full_title.trim();
+    Ok(resolution)
 }
 
 fn parse_episode_identifier<'s>(
@@ -42,6 +55,19 @@ fn batch_range<'s>(input: &mut &'s str) -> PResult<RangeInclusive<u32>, InputErr
         .parse_next(input)
 }
 
+fn parse_batch_range<'s>(input: &mut &'s str) -> PResult<RangeInclusive<u32>, InputError<&'s str>> {
+    let Some(index) = input.rfind('(') else {
+        return Err(ErrMode::Backtrack(InputError::from_error_kind(
+            input,
+            ErrorKind::Assert,
+        )));
+    };
+    let mut range = &input[index..];
+    let batch_range = batch_range.parse_next(&mut range)?;
+    *input = &input[..index];
+    Ok(batch_range)
+}
+
 fn square_brackets<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
     delimited('[', take_till(0.., |c| c == ']'), ']').parse_next(input)
 }
@@ -60,13 +86,11 @@ pub(crate) fn parse_filename(value: &str) -> PResult<ParsedDownload, InputError<
     let full_title = take_till(0.., |c| c == '[').parse_next(&mut value_ref)?;
     let hash_or_batch = parse_file_end.parse_next(&mut value_ref)?;
     value_ref = full_title.trim();
+    let resolution = parse_resolution(&mut value_ref)?;
     match hash_or_batch {
         "Batch" => {
-            let full_title = take_till(0.., |c| c == '(').parse_next(&mut value_ref)?;
-            let range = batch_range.parse_next(&mut value_ref)?;
-            space1.parse_next(&mut value_ref)?;
-            let resolution = resolution.parse_next(&mut value_ref)?;
-            let title = full_title.trim();
+            let range = parse_batch_range.parse_next(&mut value_ref)?;
+            let title = value_ref.trim();
             Ok(ParsedDownload {
                 source,
                 title,
@@ -74,36 +98,31 @@ pub(crate) fn parse_filename(value: &str) -> PResult<ParsedDownload, InputError<
                 resolution,
             })
         }
-        _ => {
-            let full_title = take_till(0.., |c| c == '(').parse_next(&mut value_ref)?;
-            let resolution = resolution.parse_next(&mut value_ref)?;
-            let full_title = full_title.trim();
-            match full_title.rfind("- ") {
-                None => Ok(ParsedDownload {
-                    source,
-                    title: full_title,
-                    download_type: ParsedDownloadVariant::Movie,
-                    resolution,
-                }),
-                Some(index) => {
-                    let mut slice = full_title[index..].trim_start_matches(['-', ' ', '#']);
-                    match parse_episode_identifier(&mut slice)? {
-                        None => Ok(ParsedDownload {
-                            source,
-                            title: full_title,
-                            download_type: ParsedDownloadVariant::Movie,
-                            resolution,
-                        }),
-                        Some(ep) => Ok(ParsedDownload {
-                            source,
-                            title: full_title[..index].trim(),
-                            download_type: ParsedDownloadVariant::Episode(ep),
-                            resolution,
-                        }),
-                    }
+        _ => match value_ref.rfind("- ") {
+            None => Ok(ParsedDownload {
+                source,
+                title: value_ref,
+                download_type: ParsedDownloadVariant::Movie,
+                resolution,
+            }),
+            Some(index) => {
+                let mut slice = value_ref[index..].trim_start_matches(['-', ' ', '#']);
+                match parse_episode_identifier(&mut slice)? {
+                    None => Ok(ParsedDownload {
+                        source,
+                        title: value_ref,
+                        download_type: ParsedDownloadVariant::Movie,
+                        resolution,
+                    }),
+                    Some(ep) => Ok(ParsedDownload {
+                        source,
+                        title: value_ref[..index].trim(),
+                        download_type: ParsedDownloadVariant::Episode(ep),
+                        resolution,
+                    }),
                 }
             }
-        }
+        },
     }
 }
 
@@ -125,6 +144,19 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_filename_batch_with_extra_brackets() {
+        let input = "[SubsPlease] Urusei Yatsura (2022) (01-08) (1080p) [Batch]";
+        let expected = ParsedDownload {
+            source: "SubsPlease",
+            title: "Urusei Yatsura (2022)",
+            download_type: ParsedDownloadVariant::Batch(1..=8),
+            resolution: 1080,
+        };
+        let result = parse_filename(input);
+        assert_eq!(result, Ok(expected));
+    }
+
+    #[test]
     fn test_parse_filename_movie() {
         let input = "[SubsPlease] Boku no Hero Academia - UA Heroes Battle (720p) [F3A40F62].mkv";
         let expected = ParsedDownload {
@@ -138,6 +170,19 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_filename_movie_with_extra_brackets() {
+        let input = "[SubsPlease] Urusei Yatsura (2022) (1080p) [F3A40F62].mkv";
+        let expected = ParsedDownload {
+            source: "SubsPlease",
+            title: "Urusei Yatsura (2022)",
+            download_type: ParsedDownloadVariant::Movie,
+            resolution: 1080,
+        };
+        let result = parse_filename(input);
+        assert_eq!(result, Ok(expected));
+    }
+
+    #[test]
     fn test_parse_filename_episode() {
         let input = "[SubsPlease] 16bit Sensation - Another Layer - 10 (1080p) [2A96C634].mkv";
         let expected = ParsedDownload {
@@ -145,6 +190,24 @@ mod tests {
             title: "16bit Sensation - Another Layer",
             download_type: ParsedDownloadVariant::Episode(ParsedEpisode {
                 number: 10,
+                decimal: None,
+                version: None,
+                extra: None,
+            }),
+            resolution: 1080,
+        };
+        let result = parse_filename(input);
+        assert_eq!(result, Ok(expected));
+    }
+
+    #[test]
+    fn test_parse_filename_episode_with_extra_brackets() {
+        let input = "[SubsPlease] Urusei Yatsura (2022) - 25 (1080p) [C0AF019E].mkv";
+        let expected = ParsedDownload {
+            source: "SubsPlease",
+            title: "Urusei Yatsura (2022)",
+            download_type: ParsedDownloadVariant::Episode(ParsedEpisode {
+                number: 25,
                 decimal: None,
                 version: None,
                 extra: None,


### PR DESCRIPTION
Streamlined subtitle file parsing within the `subs_please.rs` file. Parsing functions for resolution and batch ranges have been introduced which separately handle resolution and batch details. This, along with updated edge cases in the associated unit tests, should lead to more accurate title parsing.