### PR TITLE
Refactor poller start and tick mechanism

### DIFF
--- a/src/bin/anime-service.rs
+++ b/src/bin/anime-service.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<()> {
     let app_state = AppState::new()?;
     sqlx::migrate!().run(&app_state.pool).await?;
     let poller = poller::Poller::persistent_from_state(&app_state).await?;
-    poller.start_with_period(Duration::from_secs(60))?;
+    poller.start()?;
 
     anime_service::serve_combined(app_state).await?;
     Ok(())

--- a/src/bin/anime-service.rs
+++ b/src/bin/anime-service.rs
@@ -1,7 +1,7 @@
-use anime_service::{jobs::poller, state::AppState};
 use anyhow::Result;
-use std::time::Duration;
 use tracing_subscriber::prelude::*;
+
+use anime_service::{jobs::poller, state::AppState};
 
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
Refactored code in `anime-service.rs` and `poller.rs`. Reduce load on nyaa by using a longer update interval. Additionally, a dedicated `tick()` method was introduced to tidy up the loop operation within the spawning of the poller task.