### PR TITLE
Add concurrency settings to GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,10 @@ on:
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io


### PR DESCRIPTION
Concurrency settings have been added to `.github/workflows/docker-image.yml` and `.github/workflows/ci.yml` to ensure that GitHub actions jobs are executed sequentially and not simultaneously, thereby potentially preventing inconsistent build and deployment results. This approach also cancels any in-progress jobs if a new job from the same pull request or branch is triggered.